### PR TITLE
Fixed slight annoyance

### DIFF
--- a/colors/Monokai.vim
+++ b/colors/Monokai.vim
@@ -10,7 +10,7 @@ endif
 
 let g:colors_name = "Monokai"
 
-hi Cursor ctermfg=NONE ctermbg=231 cterm=NONE guifg=NONE guibg=#f8f8f0 gui=NONE
+hi Cursor ctermfg=NONE ctermbg=231 cterm=NONE guifg=#000000 guibg=#f8f8f0 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#49483e gui=NONE
 hi CursorLine ctermfg=NONE ctermbg=237 cterm=NONE guifg=NONE guibg=#3c3d37 gui=NONE
 hi CursorColumn ctermfg=NONE ctermbg=237 cterm=NONE guifg=NONE guibg=#3c3d37 gui=NONE


### PR DESCRIPTION
In the colorscheme, the white cursor hides white text behind it and makes it appear hidden. This means you don't know what character is under the cursor.

By setting:

``` viml
hi Cursor guifg=#000000 guibg=#ffffff
```

Anything white will appear black when the cursor is over it, and not hide it.
