### PR TITLE
Made Cursor guifg same color as normal background color

### DIFF
--- a/colors/Monokai.vim
+++ b/colors/Monokai.vim
@@ -10,7 +10,7 @@ endif
 
 let g:colors_name = "Monokai"
 
-hi Cursor ctermfg=NONE ctermbg=231 cterm=NONE guifg=NONE guibg=#f8f8f0 gui=NONE
+hi Cursor ctermfg=235 ctermbg=231 cterm=NONE guifg=#272822 guibg=#f8f8f0 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#49483e gui=NONE
 hi CursorLine ctermfg=NONE ctermbg=237 cterm=NONE guifg=NONE guibg=#3c3d37 gui=NONE
 hi CursorColumn ctermfg=NONE ctermbg=237 cterm=NONE guifg=NONE guibg=#3c3d37 gui=NONE


### PR DESCRIPTION
As requested, I've fixed it up along with `ctermfg` for Color-Terminal support.
