### PR TITLE
Lowercase name

### DIFF
--- a/colors/monokai.vim
+++ b/colors/monokai.vim
@@ -8,7 +8,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "Monokai"
+let g:colors_name = "monokai"
 
 hi Cursor ctermfg=235 ctermbg=231 cterm=NONE guifg=#272822 guibg=#f8f8f0 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#49483e gui=NONE


### PR DESCRIPTION
Having the name be uppercase breaks convention and and prevents it from showing up correctly in the alphabetical colorscheme list at :colorscheme<Tab>. Also, on case-sensitive systems, this may break a vimrc at `colorscheme monokai`. Making this lowercase avoids confusion and sticks with convention in all cases.
