### PR TITLE
explicitly set colors to 256

### DIFF
--- a/colors/monokai.vim
+++ b/colors/monokai.vim
@@ -8,6 +8,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
+set t_Co=256
 let g:colors_name = "monokai"
 
 hi Cursor ctermfg=235 ctermbg=231 cterm=NONE guifg=#272822 guibg=#f8f8f0 gui=NONE


### PR DESCRIPTION
While testing, this color scheme first didn't work for me (linux, xfce4-terminal and gnome-terminal; worked on xterm). To be sure, explicitly call 256 colors for this scheme.
