### PR TITLE
Add initial Treesitter highlight groups

### DIFF
--- a/colors/monokai.vim
+++ b/colors/monokai.vim
@@ -64,6 +64,10 @@ hi SpecialChar ctermfg=141 ctermbg=NONE cterm=NONE guifg=#ae81ff guibg=NONE gui=
 hi Statement ctermfg=197 ctermbg=NONE cterm=NONE guifg=#f92672 guibg=NONE gui=NONE
 hi StorageClass ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
 hi String ctermfg=186 ctermbg=NONE cterm=NONE guifg=#e6db74 guibg=NONE gui=NONE
+hi TSConstant ctermfg=242 ctermbg=NONE cterm=NONE guifg=#75715e guibg=NONE gui=NONE
+hi TSTag ctermfg=197 ctermbg=NONE cterm=NONE guifg=#f92672 guibg=NONE gui=NONE
+hi TSTagDelimiter ctermfg=148 ctermbg=NONE cterm=NONE guifg=#a6e22e guibg=NONE gui=NONE
+hi TSType ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
 hi Tag ctermfg=197 ctermbg=NONE cterm=NONE guifg=#f92672 guibg=NONE gui=NONE
 hi Title ctermfg=231 ctermbg=NONE cterm=bold guifg=#f8f8f2 guibg=NONE gui=bold
 hi Todo ctermfg=95 ctermbg=NONE cterm=inverse,bold guifg=#75715e guibg=NONE gui=inverse,bold


### PR DESCRIPTION
When using Treesitter with Neovim, some of the highlight groups are off. Setting these four groups fixes most of the problems I've had with Ruby and HTML.

By the way, I've started my own Monokai scheme in Lua for Neovim using the colors from this repo as a base: https://github.com/kstevens715/monokai.nvim. I'll try and submit more PR's as I come up with other fixes for Treesitter.

**Before Changes (with Treesitter on)**
<img width="1231" alt="Screen Shot 2022-06-13 at 9 01 27 PM" src="https://user-images.githubusercontent.com/1191305/173471835-c8b6339a-d0eb-447a-bb61-bc801d07e742.png">

**After Changes (with Treesitter on)**
<img width="1231" alt="Screen Shot 2022-06-13 at 9 14 45 PM" src="https://user-images.githubusercontent.com/1191305/173472844-947f8f90-62b6-404d-92ac-f5d767a050b2.png">

**Before Changes (with Treesitter off)**
<img width="1231" alt="Screen Shot 2022-06-13 at 9 10 27 PM" src="https://user-images.githubusercontent.com/1191305/173472468-c6819554-7d8d-4a50-bfac-deca426f329e.png">

